### PR TITLE
Make galaxy-table seeding deterministic across processes

### DIFF
--- a/mejiro/pipeline/_01a_generate_galaxy_tables.py
+++ b/mejiro/pipeline/_01a_generate_galaxy_tables.py
@@ -126,7 +126,7 @@ def generate_galaxy_table(tuple):
 
     # seed for reproducibility
     global_seed = config.get('seed', 42)
-    np.random.seed(hash((global_seed, 'table', table_index)) % (2**32))
+    np.random.seed(hash((global_seed, table_index, 0)) % (2**32))
 
     # suppress warnings
     if config['suppress_warnings']:


### PR DESCRIPTION
The per-table seed in _01a used hash((global_seed, 'table', table_index)), whose string element is hashed non-deterministically per process via PYTHONHASHSEED. This defeated the configured seed:42 reproducibility and made test_pipeline_run flaky: some CI runs drew a galaxy population with zero detectable lenses, so 01b wrote no detectable_gglenses_*.pkl and 02 raised FileNotFoundError.

Use an all-integer tuple, matching 01b's process-stable pattern, so the draw is reproducible on every machine/run. The trailing 0 keeps table seeds distinct from 01b's run seeds.